### PR TITLE
Feat: 카카오맵 api 사용한 홈 지도 연결

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Gachi Taxi</title>
+    <script
+      type="text/javascript"
+      src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=d858f2cf89c907a66f9d4a396414f18f&autoload=false"
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/home/KakaoMap.tsx
+++ b/src/components/home/KakaoMap.tsx
@@ -1,0 +1,91 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useEffect, useState, memo } from 'react';
+import getRouteLine from '@/libs/apis/kakaoMobility.api';
+import { ORIGIN, DESTINATION } from '@/constants';
+
+declare global {
+  interface Window {
+    kakao: any;
+  }
+}
+
+const KakaoMap = memo(() => {
+  const [isKakaoLoaded, setIsKakaoLoaded] = useState(false);
+  const [map, setMap] = useState(null);
+  const origin = ORIGIN;
+  const destination = DESTINATION;
+
+  // 스크립트로 카카오맵 api 호출
+  useEffect(() => {
+    if (window.kakao) {
+      window.kakao.maps.load(() => {
+        setIsKakaoLoaded(true);
+      });
+    }
+  }, []);
+
+  // 로드 완료 후 map 객체 생성
+  useEffect(() => {
+    if (isKakaoLoaded && window.kakao) {
+      const container = document.getElementById('map');
+      const options = {
+        center: new window.kakao.maps.LatLng(
+          37.45065010968753,
+          127.13095078158204,
+        ),
+        level: 4,
+      };
+      const kakaoMap = new window.kakao.maps.Map(container, options);
+      setMap(kakaoMap);
+    }
+  }, [isKakaoLoaded]);
+
+  // 카카오 모빌리티 api 사용한 출발지 -> 목적지 경로 렌더링
+  useEffect(() => {
+    const drawRoute = async () => {
+      if (!map) return;
+
+      try {
+        const response = await getRouteLine({ origin, destination });
+        const { routes } = response;
+
+        if (routes && routes[0]?.sections) {
+          const polylinePath: any[] = [];
+          routes[0].sections.forEach((section: any) => {
+            section.roads.forEach((road: any) => {
+              road.vertexes.forEach((_vertex: any, index: number) => {
+                if (index % 2 === 0) {
+                  polylinePath.push(
+                    new window.kakao.maps.LatLng(
+                      road.vertexes[index + 1],
+                      road.vertexes[index],
+                    ),
+                  );
+                }
+              });
+            });
+          });
+
+          const polyline = new window.kakao.maps.Polyline({
+            map,
+            path: polylinePath,
+            strokeWeight: 10,
+            strokeColor: '#007AFF',
+            strokeOpacity: 1,
+            strokeStyle: 'solid',
+          });
+
+          polyline.setMap(map);
+        }
+      } catch (error) {
+        console.error('Error drawing route:', error);
+      }
+    };
+
+    drawRoute();
+  }, [map, origin, destination]);
+
+  return <div id="map" className="w-full h-[85vh] z-20"></div>;
+});
+
+export default KakaoMap;

--- a/src/components/home/MatchingSheet.tsx
+++ b/src/components/home/MatchingSheet.tsx
@@ -21,7 +21,7 @@ const MatchingSheet = ({ modalContent }: MatchingSheetProps) => {
   return (
     <motion.div
       role="Viewer"
-      className="absolute left-0 top-0 w-full mx-auto h-[100lvh] touch-none bg-neutral rounded-t-common will-change-transform p-vertical px-[32px] flex flex-col gap-[16px]"
+      className="absolute left-0 top-0 w-full mx-auto h-[100lvh] touch-none bg-neutral rounded-t-common will-change-transform p-vertical px-[32px] flex flex-col gap-[16px] z-30"
       drag="y"
       dragConstraints={{
         top: 0, // opend 상태일 때 드래그 제한 적용

--- a/src/components/home/Navbar.tsx
+++ b/src/components/home/Navbar.tsx
@@ -20,7 +20,7 @@ interface NavbarProps {
 
 const Navbar = ({ modalContent, setModalContent }: NavbarProps) => {
   return (
-    <nav className="flex justify-between items-center bg-neutral fixed left-0 right-0 bottom-0 max-w-[430px] w-full h-[64px] px-8 mx-auto">
+    <nav className="flex justify-between items-center bg-neutral fixed left-0 right-0 bottom-0 max-w-[430px] w-full h-[64px] px-8 mx-auto z-40">
       <Button
         variant="icon"
         className="flex flex-col items-center justify-center gap-1"

--- a/src/components/home/autoMatching/RouteSetting.tsx
+++ b/src/components/home/autoMatching/RouteSetting.tsx
@@ -3,6 +3,7 @@ import RouteChangeIcon from '@/assets/icon/routeChangeIcon.svg?react';
 import Button from '@/components/commons/Button';
 
 interface RouteSettingProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   matchingData: any;
   handleRouteChange: () => void;
 }

--- a/src/components/home/manualMatching/MatchingPage.tsx
+++ b/src/components/home/manualMatching/MatchingPage.tsx
@@ -20,9 +20,9 @@ const MatchingPage = ({
       <div
         className={`flex flex-col gap-[16px] ${isOpen ? '' : 'pb-[calc(100dvh-430px)]'} min-h-[200px] max-h-[calc(100dvh-225px)] overflow-y-scroll scroll-hidden`}
       >
-        {manualInfos.map((manualInfo) => {
+        {manualInfos.map((manualInfo, idx) => {
           return (
-            <Link to={`/signup/verification`}>
+            <Link key={idx} to={`/signup/verification`}>
               <MatchingInfoBox manualInfo={manualInfo} />
             </Link>
           );

--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -32,3 +32,6 @@ export const BUTTON_DATA = [
     isVerified: false,
   },
 ];
+
+export const ORIGIN = '127.12692157601926,37.45052385846493';
+export const DESTINATION = '127.13467190126833,37.45543030528147';

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,10 @@
   }
   body {
     background-color: #011a11;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
   }
 }
 

--- a/src/libs/apis/kakaoMobility.api.ts
+++ b/src/libs/apis/kakaoMobility.api.ts
@@ -1,0 +1,28 @@
+import axios from 'axios';
+
+const REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
+
+interface QueryTypes {
+  origin: string;
+  destination: string;
+}
+
+const getRouteLine = async ({ origin, destination }: QueryTypes) => {
+  try {
+    const res = await axios.get(
+      `https://apis-navi.kakaomobility.com/v1/directions?origin=${origin}&destination=${destination}`,
+      {
+        headers: {
+          Authorization: `KakaoAK ${REST_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    return res.data;
+  } catch (error) {
+    throw new Error(`Error fetching route: ${error}`);
+  }
+};
+
+export default getRouteLine;

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,6 +1,8 @@
 import MatchingSheet from '@/components/home/MatchingSheet';
 import Navbar from '@/components/home/Navbar';
-import { useState } from 'react';
+import { useState, Suspense, lazy } from 'react';
+
+const KakaoMap = lazy(() => import('@/components/home/KakaoMap'));
 
 const HomePage = () => {
   const [modalContent, setModalContent] = useState({
@@ -10,7 +12,10 @@ const HomePage = () => {
   });
 
   return (
-    <section className="w-full flex-1 overflow-hidden p-[16px] relative bg-neutral">
+    <section className="w-full flex-1 overflow-hidden relative bg-neutral">
+      <Suspense fallback={<div className="bg-white h-[85vh]">로딩중...</div>}>
+        <KakaoMap />
+      </Suspense>
       <MatchingSheet modalContent={modalContent} />
       <Navbar modalContent={modalContent} setModalContent={setModalContent} />
     </section>


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

<br>

## 3. 관련 스크린샷을 첨부해주세요.
![image](https://github.com/user-attachments/assets/e9044398-1385-42a5-a7eb-8eb3480dc81b)
<br>

## 4. 완료 사항

카카오 맵과 카카오 모빌리티 api 사용해서 `home` 페이지에 지도 및 경로 렌더링 로직 작성했습니다!
원래 따로 권한 설정이 필요없던 걸로 알고 있었어서 계속 삽질했네요;;

요번에 정책이 변경돼서 이제 앱 권한 설정을 통해 카카오맵 api 사용 권한을 받아야 사용이 가능해졌는데, 이 권한이 비즈니스 앱으로 서비스를 전환할 경우에만 사용이 가능해져서.. 저희 프로덕션으로 배포하고 나면 설정을 다시 해줘야 할 것 같습니다! 

보시면 스크립트에 api 키가 그대로 노출되고 있긴한데... 이건 html 부분이라 그런지 `KakaoMap` 컴포넌트 내부에서 환경변수 이용해서 가린 상태로 동적 추가 처리해줘도 브라우저에는 그대로 api 키가 출력되는걸 확인해서 그냥 `index` 파일에 스크립트 태그로 때려박았습니다 😂
eslint 관련해서 주석처리해둔 것들은 any 타입 관련한 것들인데 저희쪽 컴포넌트는 api 나오면 타입 지정해서 변경해줄거고 카카오쪽은 애초에 타입스크립트를 염두에 두고 만든 게 아닌가봐요.. 다들 any로 처리하길래 얘만 부득이하게 이렇게 지정해놨습니다!!
<br>

## 5. 추가 사항

지도가 변하는게 없는데도 계속 렌더링돼서 `memo` 사용해서 매핑해주고 `Suspense` 사용해서 로딩 처리도 임의로 해줬는데 요건 화요일에 로딩 관련해서 나오는게 있으면 차차 수정하는걸로 하겠습니다!
<br>
